### PR TITLE
Add LD_LIBRARY_PATH to ENV_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,7 @@ indent() {
 
 echo "-----> Installing lame"
 BUILD_DIR=$1
+ENV_DIR=$3
 VENDOR_DIR="vendor"
 DOWNLOAD_URL="https://github.com/lepinsk/heroku-buildpack-lame/raw/master/lame.tar.gz"
 
@@ -21,3 +22,6 @@ PROFILE_PATH="$BUILD_DIR/.profile.d/lame.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="$PATH:vendor/lame/bin"' >> $PROFILE_PATH
 echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/lame/lib"' >> $PROFILE_PATH
+
+. $PROFILE_PATH
+echo $LD_LIBRARY_PATH >> $ENV_DIR/LD_LIBRARY_PATH


### PR DESCRIPTION
Thanks for this lifesaving buildpack!

It still works with Heroku's built-in composable buildpack support except in one regard: the environment variable is not available to subsequent buildpacks (only at runtime). That means if you need libmp3lame.so in your later buildpacks, it's not available.

But by dropping it into ENV_DIR as a config variable, it's then available to the later buildpacks - so that's what this PR does.

Let me know if you have any questions!